### PR TITLE
aucoalesce: Be more forgiving of compound events.

### DIFF
--- a/aucoalesce/coalesce.go
+++ b/aucoalesce/coalesce.go
@@ -218,9 +218,10 @@ func normalizeCompound(msgs []*auparse.AuditMessage) (*Event, error) {
 			break
 		}
 	}
-	if syscall == nil {
-		// All compound records have syscall messages.
-		return nil, errors.New("missing syscall message in compound event")
+	if special == nil && syscall == nil {
+		return nil, &CompoundEventError{
+			message: "compound event's special and syscall audit messages are nil",
+		}
 	}
 
 	event := newEvent(special, syscall)

--- a/aucoalesce/errors.go
+++ b/aucoalesce/errors.go
@@ -1,0 +1,11 @@
+package aucoalesce
+
+// CompoundEventError is returned by CoalesceMessages when a compound
+// audit event cannot be parsed.
+type CompoundEventError struct {
+	message string
+}
+
+func (o *CompoundEventError) Error() string {
+	return o.message
+}


### PR DESCRIPTION
The CoalesceMessages function takes one or more audit messages and creates an Event object. An Event containing more than one message is known as a "compound event".

Prior to this commit, the compound event parsing logic required that a "syscall" message be included in the slice passed to the function. This requirement may be a little over-zealous. In GitHub issue 127, we discovered examples of audit events that did not include a syscall message. [1] This resulted in CoalesceMessages returning an error.

This commit modifies the syscall message check to only return an error if both the "special" and syscall audit messages are missing. In such a case, a new (testable) error is returned.

1. https://github.com/elastic/go-libaudit/issues/127